### PR TITLE
Clarify plugin only works in Reading view

### DIFF
--- a/src/settings/GitHubEmbedsSettingsTab.ts
+++ b/src/settings/GitHubEmbedsSettingsTab.ts
@@ -1,6 +1,6 @@
 import { App, PluginSettingTab } from 'obsidian';
 import GithubEmbedsPlugin from '../main';
-import { FileSection, GithubSection, IssueSection, SupportSection } from './sections';
+import { DisclaimerSection, FileSection, GithubSection, IssueSection, SupportSection } from './sections';
 
 export class GitHubEmbedsSettingsTab extends PluginSettingTab {
 	constructor(
@@ -15,6 +15,7 @@ export class GitHubEmbedsSettingsTab extends PluginSettingTab {
 
 		containerEl.empty();
 
+		new DisclaimerSection(this);
 		new GithubSection(this);
 		new IssueSection(this);
 		new FileSection(this);

--- a/src/settings/sections/DisclaimerSection.module.scss
+++ b/src/settings/sections/DisclaimerSection.module.scss
@@ -1,0 +1,17 @@
+.container {
+	font-size: var(--font-smallest);
+
+	:global(.callout) {
+		// For some reason the callout's default blend mode causes the title to be cut off.
+		mix-blend-mode: normal;
+
+		:global(.callout-title) {
+			align-items: center;
+		}
+
+		:global(svg.svg-icon) {
+			width: 1.15em;
+			height: 1.15em;
+		}
+	}
+}

--- a/src/settings/sections/DisclaimerSection.ts
+++ b/src/settings/sections/DisclaimerSection.ts
@@ -1,0 +1,22 @@
+import { BaseSection } from './BaseSection';
+import { renderMarkdown } from '../../utilities';
+import styles from './DisclaimerSection.module.scss';
+
+export class DisclaimerSection extends BaseSection {
+	protected title(): string | undefined {
+		return undefined;
+	}
+
+	protected onload(): void {
+		renderMarkdown(
+			this.app,
+			`> [!info] Note\n> ${this.disclaimerText}`,
+			this.containerEl.createDiv(styles.container),
+			this.plugin,
+		);
+	}
+
+	private get disclaimerText(): string {
+		return 'Please note that this plugin currently only renders embeds while in **Reading** view.';
+	}
+}

--- a/src/settings/sections/index.ts
+++ b/src/settings/sections/index.ts
@@ -1,3 +1,4 @@
+export { DisclaimerSection } from './DisclaimerSection';
 export { FileSection } from './FileSection';
 export { GithubSection } from './GithubSection';
 export { IssueSection } from './IssueSection';


### PR DESCRIPTION
Fixes #9

Added a disclaimer to the Settings panel to let users know that this plugin currently only works while in Reading view.

<img width="100%" alt="settings_disclaimer" src="https://github.com/MrGVSV/obsidian-github-embeds/assets/49806985/46cdbcad-f21a-4926-a9f6-27869bd643c9">
