### PR TITLE
Limit codeblocks to a defined set of languages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "github-embeds",
-	"version": "1.0.3",
+	"version": "1.0.6",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "github-embeds",
-			"version": "1.0.3",
+			"version": "1.0.6",
 			"license": "MIT",
 			"dependencies": {
 				"@apollo/client": "^3.8.1",
@@ -24,6 +24,7 @@
 				"@graphql-codegen/typescript": "4.0.1",
 				"@graphql-codegen/typescript-operations": "^4.0.1",
 				"@types/node": "^16.11.6",
+				"@types/prismjs": "^1.26.3",
 				"@types/tinycolor2": "^1.4.3",
 				"@typescript-eslint/eslint-plugin": "^6.14.0",
 				"@typescript-eslint/parser": "^6.14.0",
@@ -2945,6 +2946,12 @@
 			"version": "16.18.39",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.39.tgz",
 			"integrity": "sha512-8q9ZexmdYYyc5/cfujaXb4YOucpQxAV4RMG0himLyDUOEr8Mr79VrqsFI+cQ2M2h89YIuy95lbxuYjxT4Hk4kQ==",
+			"dev": true
+		},
+		"node_modules/@types/prismjs": {
+			"version": "1.26.3",
+			"resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.3.tgz",
+			"integrity": "sha512-A0D0aTXvjlqJ5ZILMz3rNfDBOx9hHxLZYv2by47Sm/pqW35zzjusrZTryatjN/Rf8Us2gZrJD+KeHbUSTux1Cw==",
 			"dev": true
 		},
 		"node_modules/@types/semver": {
@@ -9405,6 +9412,12 @@
 			"version": "16.18.39",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.39.tgz",
 			"integrity": "sha512-8q9ZexmdYYyc5/cfujaXb4YOucpQxAV4RMG0himLyDUOEr8Mr79VrqsFI+cQ2M2h89YIuy95lbxuYjxT4Hk4kQ==",
+			"dev": true
+		},
+		"@types/prismjs": {
+			"version": "1.26.3",
+			"resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.3.tgz",
+			"integrity": "sha512-A0D0aTXvjlqJ5ZILMz3rNfDBOx9hHxLZYv2by47Sm/pqW35zzjusrZTryatjN/Rf8Us2gZrJD+KeHbUSTux1Cw==",
 			"dev": true
 		},
 		"@types/semver": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"@graphql-codegen/typescript": "4.0.1",
 		"@graphql-codegen/typescript-operations": "^4.0.1",
 		"@types/node": "^16.11.6",
+		"@types/prismjs": "^1.26.3",
 		"@types/tinycolor2": "^1.4.3",
 		"@typescript-eslint/eslint-plugin": "^6.14.0",
 		"@typescript-eslint/parser": "^6.14.0",

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -4,7 +4,7 @@ import { IssueDocument } from '../queries/Issue.graphql';
 import { ApolloClient, ApolloQueryResult, DocumentNode, from, HttpLink, InMemoryCache } from '@apollo/client/core';
 import { RetryLink } from '@apollo/client/link/retry';
 import { Content, FileSnippet, FileUrl, IssueUrl } from './types';
-import { extractLines, extToLang } from '../utilities';
+import { extractLines, Langs } from '../utilities';
 import { BranchDocument, BranchQueryVariables } from '../queries/Branch.graphql';
 
 const issueRegex = /^https:\/\/github\.com\/([\w-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)/i;
@@ -165,7 +165,7 @@ export class Client {
 						end: endLine ? parseInt(endLine) : undefined,
 				  }
 				: undefined,
-			lang: extToLang(ext),
+			lang: Langs.get(ext),
 		};
 	}
 

--- a/src/components/core/Shard.ts
+++ b/src/components/core/Shard.ts
@@ -1,6 +1,6 @@
 import { Component, sanitizeHTMLToDom } from 'obsidian';
 import { nanoid } from 'nanoid';
-import { replaceAdmonitions, replaceCodeBlocks } from '../../utilities';
+import { sanitizeHtml } from '../../utilities';
 import { SettingsProvider } from '../../settings';
 
 type Ctor1 = [parent: Shard, tag: keyof HTMLElementTagNameMap, o?: DomElementInfo | string];
@@ -202,8 +202,7 @@ export class Shard extends Component {
 		const shard = this.createShard(tag, o, callback);
 		shard.element.append(sanitizeHTMLToDom(html));
 
-		replaceAdmonitions(this.settings.app, shard.element, this);
-		replaceCodeBlocks(this.settings.app, shard.element, this);
+		sanitizeHtml(shard);
 
 		return shard;
 	}

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import { FileEmbed } from './postprocessing/FileEmbed';
 import { LoadingEmbed } from './postprocessing/LoadingEmbed';
 import styles from './styles.scss';
 import { EmbedContainer } from './postprocessing/EmbedContainer';
+import { Langs } from './utilities';
 
 // Initialize Apollo Client __DEV__ variable
 window.__DEV__ = process.env.NODE_ENV === 'development';
@@ -17,6 +18,8 @@ export default class GithubEmbedsPlugin extends SettingsProvider {
 	private client: Client | null = null;
 
 	async onload() {
+		await Langs.initialize(this.app, this);
+
 		await this.loadSettings();
 		this.addSettingTab(new GitHubEmbedsSettingsTab(this.app, this));
 

--- a/src/utilities/general.ts
+++ b/src/utilities/general.ts
@@ -1,0 +1,6 @@
+/**
+ * Run the given function only if the plugin is in development mode.
+ */
+export function debug<T = void>(f: () => T): T | undefined {
+	return window.__DEV__ ? f() : undefined;
+}

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,5 +1,6 @@
 export * from './appearance';
 export * from './dom';
+export * from './general';
 export * from './graphql';
 export * from './languages';
 export * from './strings';

--- a/src/utilities/languages.ts
+++ b/src/utilities/languages.ts
@@ -1,29 +1,105 @@
-/**
- * Maps file extensions to language names supported by PrismJS.
- *
- * This list only contains languages whose extensions are not already a valid language
- * tag recognized by PrismJS.
- */
-const LanguageExt = new Map<string, string>(
-	Object.entries({
-		bf: 'brainfuck',
-		fs: 'fsharp',
-		gd: 'gdscript',
-		h: 'c',
-		m: 'objc',
-		rs: 'rust',
-		txt: '',
-		text: '',
-	}),
-);
+import { App, Component, MarkdownRenderer } from 'obsidian';
+import { debug } from './general';
 
-/**
- * Returns a guess for what PrismJS language tag matches the given extension.
- *
- * If no match is found, the extension itself is returned by default.
- *
- * @param ext The extension without a leading dot (`.`)
- */
-export function extToLang(ext: string): string {
-	return LanguageExt.get(ext) ?? ext;
+export class Langs {
+	/** The loaded PrismJS language tags. */
+	private static tags = new Set<string>();
+	/** The mapping of file extensions to PrismJS language tag. */
+	private static extensions = new Map<string, string>([
+		['aspx', 'aspnet'],
+		['fs', 'fsharp'],
+		['gd', 'gdscript'],
+		['h', 'c'],
+		['m', 'objc'],
+		['mm', 'objc'],
+		['text', 'text'],
+		['v', 'v'],
+		['wat', 'wasm'],
+		['wast', 'wasm'],
+	]);
+
+	/**
+	 * The total number of language tags.
+	 */
+	public static get size() {
+		return this.tags.size;
+	}
+
+	/**
+	 * Returns the PrismJS language tag for the given tag or file extension if it exists.
+	 *
+	 * @param tagOrExt The language tag (e.g. `rust`) or file extension (e.g. `rs`)
+	 *
+	 * @example
+	 * Langs.get('rust'); // 'rust'
+	 * Langs.get('rs'); // 'rust'
+	 * Langs.get('crust'); // undefined
+	 */
+	public static get(tagOrExt: string) {
+		return this.tags.has(tagOrExt) ? tagOrExt : this.extensions.get(tagOrExt);
+	}
+
+	/**
+	 * Initialize the language map.
+	 *
+	 * This should be called as early as possible in the plugin's lifecycle
+	 * to ensure that the language map is populated before it is used.
+	 */
+	public static async initialize(app: App, component: Component) {
+		if (this.size > 0) {
+			return;
+		}
+
+		// Force Obsidian to load Prism
+		await MarkdownRenderer.render(
+			app,
+			'```js\n function foo() {} \n```',
+			new DocumentFragment().createDiv(),
+			'',
+			component,
+		);
+
+		// Get all loaded PrismJS language tags
+		for (const tag of Object.keys(globalThis.Prism.languages)) {
+			if (typeof globalThis.Prism.languages[tag] !== 'object') {
+				continue;
+			}
+
+			if (this.tags.has(tag)) {
+				debug(() => console.warn(`Attempted to add language "${tag}" when it already exists`));
+				continue;
+			}
+
+			this.tags.add(tag);
+		}
+
+		// Get CodeMirror language data to map file extensions to language tags
+		for (const { name, mode, ext = [] } of globalThis.CodeMirror.modeInfo) {
+			// Try and find a corresponding tag for the language name, file extension, or mode (in that order)
+			const keys = [name.toLowerCase(), ...ext, mode];
+			const tag = keys.find((key) => this.tags.has(key));
+
+			if (!tag) {
+				debug(
+					() =>
+						keys.every((key) => !this.extensions.has(key)) &&
+						console.debug(`Could not find language for "${name}"`, ext),
+				);
+				continue;
+			}
+
+			ext.forEach((ext) => {
+				const existing = this.extensions.get(ext);
+				if (existing && existing !== tag) {
+					debug(() =>
+						console.warn(
+							`Attempted to add extension ".${ext}" for "${name}" when it already exists for "${existing}"`,
+						),
+					);
+				} else {
+					this.extensions.set(ext, tag);
+				}
+			});
+		}
+	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
 		"isolatedModules": false,
 		"strictNullChecks": true,
 		"lib": ["DOM", "ES5", "ES6", "ES7", "DOM.Iterable"],
+		"types": ["node", "prismjs", "codemirror/mode/meta"],
 		"allowSyntheticDefaultImports": true
 	},
 	"include": ["**/*.ts"]


### PR DESCRIPTION
Resolves #22

Limits the languages a codeblock can use when rendered from a GitHub issue, PR, or file.

This means that unrecognized languages, such as `dataviewjs`, will be rendered as plain text.

I'm not sure if this fully fixes the XSS issue (a plugin might choose to automatically run JS code blocks or something like that), but it should _significantly_ reduce the likelihood of anyone running into it.

> [!note]
> All languages are automatically generated based on the PrismJS languages loaded by Obsidian.

<details>
<summary><strong>Supported Languages</strong> (385 total)</summary>

Aliases are file extensions recognized by CodeMirror. We consider these to be the same as the language tag itself.

* `plain`
* `plaintext`
* `text`
* `txt` (aliases: `conf`,`def`,`list`,`log`)
* `markup`
* `html` (aliases: `htm`,`handlebars`,`hbs`)
* `mathml`
* `svg`
* `xml` (aliases: `xsl`,`xsd`,`svg`)
* `ssml`
* `atom`
* `rss`
* `css` (alias: `gss`)
* `clike`
* `javascript` (aliases: `js`,`jsonld`)
* `js`
* `abap`
* `abnf`
* `actionscript`
* `ada`
* `agda`
* `al`
* `antlr4`
* `g4`
* `apacheconf`
* `sql` (alias: `cql`)
* `apex`
* `apl` (alias: `dyalog`)
* `applescript`
* `aql`
* `c` (aliases: `h`,`ino`)
* `cpp` (aliases: `c++`,`cc`,`cxx`,`hpp`,`h++`,`hh`,`hxx`)
* `arduino`
* `ino`
* `arff`
* `armasm`
* `arm-asm`
* `arturo`
* `art`
* `asciidoc`
* `adoc`
* `csharp`
* `cs`
* `dotnet`
* `aspnet` (alias: `aspx`)
* `asm6502`
* `asmatmel`
* `autohotkey`
* `autoit`
* `avisynth`
* `avs`
* `avro-idl`
* `avdl`
* `awk`
* `gawk`
* `bash`
* `shell` (aliases: `sh`,`ksh`,`bash`)
* `basic`
* `batch`
* `bbcode`
* `shortcode`
* `bicep`
* `birb`
* `bison`
* `bnf`
* `rbnf`
* `brainfuck` (aliases: `b`,`bf`)
* `brightscript`
* `bro`
* `bsl`
* `oscript`
* `cfscript`
* `cfc`
* `chaiscript`
* `cil`
* `clojure` (aliases: `clj`,`cljc`,`cljx`,`cljs`,`edn`)
* `cmake` (alias: `cmake.in`)
* `cobol` (aliases: `cob`,`cpy`,`cbl`)
* `coffeescript` (alias: `coffee`)
* `coffee`
* `concurnas`
* `conc`
* `csp`
* `cooklang`
* `coq`
* `ruby` (alias: `rb`)
* `rb`
* `crystal` (alias: `cr`)
* `csv`
* `cue`
* `cypher` (alias: `cyp`)
* `d`
* `dart`
* `dataweave`
* `dax`
* `dhall`
* `diff` (alias: `patch`)
* `markup-templating`
* `django`
* `jinja2` (aliases: `j2`,`jinja`)
* `dns-zone-file`
* `dns-zone`
* `docker`
* `dockerfile`
* `dot`
* `gv`
* `ebnf`
* `editorconfig`
* `eiffel` (alias: `e`)
* `ejs`
* `eta`
* `elixir`
* `elm`
* `lua`
* `etlua`
* `erb`
* `erlang` (alias: `erl`)
* `excel-formula`
* `xls`
* `xlsx`
* `fsharp` (alias: `fs`)
* `factor`
* `false`
* `firestore-security-rules`
* `flow`
* `fortran` (aliases: `f`,`for`,`f77`,`f90`,`f95`)
* `ftl`
* `gml`
* `gamemakerlanguage`
* `gap`
* `gcode`
* `gdscript` (alias: `gd`)
* `gedcom`
* `gettext`
* `po`
* `gherkin` (alias: `feature`)
* `git`
* `glsl`
* `gn`
* `gni`
* `linker-script`
* `ld`
* `go`
* `go-module`
* `go-mod`
* `graphql`
* `groovy` (alias: `gradle`)
* `haml`
* `handlebars`
* `hbs`
* `haskell` (alias: `hs`)
* `hs`
* `haxe` (aliases: `hx`,`hxml`)
* `hcl`
* `hlsl`
* `hoon`
* `http`
* `hpkp`
* `hsts`
* `ichigojam`
* `icon`
* `icu-message-format`
* `idris`
* `idr`
* `ignore`
* `gitignore`
* `hgignore`
* `npmignore`
* `inform7`
* `ini`
* `io`
* `j`
* `java`
* `php` (aliases: `php3`,`php4`,`php5`,`php7`,`phtml`)
* `javadoclike`
* `javadoc`
* `javastacktrace`
* `jexl`
* `jolie`
* `jq`
* `typescript` (alias: `ts`)
* `ts`
* `jsdoc`
* `json` (alias: `map`)
* `webmanifest`
* `json5`
* `jsonp`
* `jsstacktrace`
* `julia` (alias: `jl`)
* `keepalived`
* `keyman`
* `kotlin` (alias: `kt`)
* `kt`
* `kts`
* `kumir`
* `kum`
* `kusto`
* `latex` (aliases: `ltx`,`tex`)
* `tex`
* `context`
* `latte`
* `less`
* `scheme` (aliases: `scm`,`ss`)
* `lilypond`
* `ly`
* `liquid`
* `lisp` (aliases: `cl`,`el`)
* `elisp`
* `emacs`
* `emacs-lisp`
* `livescript` (alias: `ls`)
* `llvm`
* `log`
* `lolcode`
* `magma`
* `makefile`
* `markdown` (aliases: `md`,`mkd`)
* `md`
* `mata`
* `matlab`
* `maxscript`
* `mel`
* `mermaid`
* `mizar`
* `mongodb`
* `monkey`
* `moonscript`
* `moon`
* `n1ql`
* `n4js`
* `n4jsd`
* `nand2tetris-hdl`
* `naniscript`
* `nani`
* `nasm`
* `neon`
* `nevod`
* `nginx`
* `nim`
* `nix`
* `nsis` (aliases: `nsh`,`nsi`)
* `objectivec`
* `objc` (aliases: `m`,`mm`)
* `ocaml` (aliases: `ml`,`mli`,`mll`,`mly`)
* `opencl`
* `openqasm`
* `qasm`
* `oz`
* `parigp`
* `parser`
* `pascal` (aliases: `p`,`pas`)
* `objectpascal`
* `pascaligo`
* `psl`
* `pcaxis`
* `px`
* `peoplecode`
* `pcode`
* `perl` (aliases: `pl`,`pm`)
* `phpdoc`
* `plant-uml`
* `plantuml`
* `plsql` (alias: `pls`)
* `powerquery`
* `pq`
* `mscript`
* `powershell` (aliases: `ps1`,`psd1`,`psm1`)
* `processing`
* `prolog`
* `promql`
* `properties` (aliases: `ini`,`in`)
* `protobuf` (alias: `proto`)
* `pug` (alias: `jade`)
* `puppet` (alias: `pp`)
* `pure`
* `purebasic`
* `pbfasm`
* `purescript`
* `purs`
* `python` (aliases: `pyx`,`pxd`,`pxi`,`BUILD`,`bzl`,`py`,`pyw`)
* `py`
* `qsharp`
* `qs`
* `q`
* `qml`
* `qore`
* `r` (alias: `R`)
* `racket`
* `rkt`
* `cshtml`
* `razor`
* `jsx`
* `tsx`
* `reason`
* `regex`
* `rego`
* `renpy`
* `rpy`
* `rest`
* `rip`
* `roboconf`
* `robotframework`
* `robot`
* `rust` (alias: `rs`)
* `sas`
* `sass`
* `scss`
* `scala`
* `shell-session`
* `shellsession`
* `sh-session`
* `smali`
* `smalltalk` (alias: `st`)
* `smarty` (alias: `tpl`)
* `sml` (aliases: `sig`,`fun`,`smackspec`)
* `smlnj`
* `solidity`
* `sol`
* `solution-file`
* `sln`
* `soy`
* `turtle` (alias: `ttl`)
* `trig`
* `sparql` (alias: `rq`)
* `rq`
* `splunk-spl`
* `sqf`
* `squirrel` (alias: `nut`)
* `stan`
* `stata`
* `iecst`
* `stylus` (alias: `styl`)
* `supercollider`
* `sclang`
* `swift`
* `systemd`
* `t4-templating`
* `t4-cs`
* `t4`
* `vbnet`
* `t4-vb`
* `yaml` (alias: `yml`)
* `yml`
* `tap`
* `tcl`
* `tt2`
* `textile`
* `toml`
* `tremor`
* `troy`
* `trickle`
* `twig`
* `typoscript`
* `tsconfig`
* `unrealscript`
* `uscript`
* `uc`
* `uorazor`
* `uri`
* `url`
* `v` (aliases: `sv`,`svh`)
* `vala`
* `velocity` (alias: `vtl`)
* `verilog`
* `vhdl` (alias: `vhd`)
* `vim`
* `visual-basic`
* `vb`
* `vba`
* `warpscript`
* `wasm` (aliases: `wat`,`wast`)
* `web-idl`
* `webidl`
* `wiki`
* `wolfram`
* `mathematica` (aliases: `nb`,`wl`,`wls`)
* `wl`
* `nb`
* `wren`
* `xeora`
* `xeoracube`
* `xojo`
* `xquery` (alias: `xy`)
* `yang`
* `zig`

</details>